### PR TITLE
Add Maven setup step to CI workflow

### DIFF
--- a/.github/workflows/java-ci-jdk17.yml
+++ b/.github/workflows/java-ci-jdk17.yml
@@ -17,6 +17,12 @@ jobs:
         distribution: 'corretto'
         cache: maven
         architecture: x64
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@v5.1
+      with:
+        maven-version: 3.9.16
+    - name: Maven Version
+      run: mvn --version
     - name: Build with Maven
       run: mvn -B clean verify --file pom.xml
     - name: Upload jar artifact


### PR DESCRIPTION
If we are happy to use the GitHub action https://github.com/stCarolas/setup-maven/, which is part of the GitHub Marketplace, then this actually does work to pin the Maven version.